### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-contrib-nodeunit": "~0.1.2"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
In line with https://github.com/rquadling/grunt-html2js/commit/d39083c44cda15a953647257225a24f94f805812

EDIT: forgot to mention I'm using this package with Grunt 1.x without issues. This would simply remove  this warning:
```
npm WARN grunt-html-convert@0.0.2 requires a peer of grunt@~0.4.0 but none was installed.
```